### PR TITLE
ADDED typography plugin and markdown conversion for posts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "laravel/wayfinder": "^0.1.9",
+        "league/commonmark": "^2.8",
         "spatie/laravel-medialibrary": "^11.17",
         "spatie/laravel-sluggable": "^3.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27ed73eaebbc8909054300a3a62f263f",
+    "content-hash": "4feef864677d933c1992ef43db473c58",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -10340,12 +10340,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -5,9 +5,20 @@ namespace Database\Seeders;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use League\CommonMark\CommonMarkConverter;
 
 class PostSeeder extends Seeder
 {
+    private CommonMarkConverter $markdown;
+
+    public function __construct()
+    {
+        $this->markdown = new CommonMarkConverter([
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ]);
+    }
+
     /**
      * Demo posts with realistic French content.
      */
@@ -124,7 +135,7 @@ class PostSeeder extends Seeder
                 ->create([
                     'title' => $postData['title'],
                     'excerpt' => $postData['excerpt'],
-                    'content' => $postData['content'],
+                    'content' => $this->markdown->convert($postData['content'])->getContent(),
                     'published_at' => $publishedAt,
                     'created_at' => $publishedAt->copy()->subHours(rand(1, 24)),
                     'view_count' => fake()->numberBetween(50, 3000),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "@inertiajs/vue3": "^2.1.0",
+                "@tailwindcss/typography": "^0.5.19",
                 "@tiptap/extension-image": "^3.17.1",
                 "@tiptap/extension-link": "^3.17.1",
                 "@tiptap/extension-placeholder": "^3.17.1",
@@ -1507,6 +1508,31 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@tailwindcss/typography": {
+            "version": "0.5.19",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+            "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "6.0.10"
+            },
+            "peerDependencies": {
+                "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+            }
+        },
+        "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/@tailwindcss/vite": {
             "version": "4.1.17",
             "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.17.tgz",
@@ -2894,7 +2920,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
@@ -5549,7 +5574,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "dependencies": {
         "@inertiajs/vue3": "^2.1.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tiptap/extension-image": "^3.17.1",
         "@tiptap/extension-link": "^3.17.1",
         "@tiptap/extension-placeholder": "^3.17.1",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 @import 'tw-animate-css';
 


### PR DESCRIPTION
- Added @tailwindcss/typography for prose styling (headings, paragraphs, code blocks)
- Added league/commonmark to convert seeder markdown content to HTML
- Updated PostSeeder to convert markdown to HTML on seeding